### PR TITLE
Access runtime via Function.getRuntime()

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,9 @@ module.exports = function(ServerlessPlugin, serverlessPath) {
              responses: [Object] } ] }
        */
 
-        if( fun.runtime == 'nodejs' ) {
+        let runtime = fun.getRuntime();
+
+        if( runtime == 'nodejs' ) {
           let handlerParts = fun.handler.split('/').pop().split('.');
           let handlerPath = path.join(fun._config.fullPath, handlerParts[0] + '.js');
           let handler;


### PR DESCRIPTION
Function's runtime should be retrieved from `Function.getRuntime()`, as the runtime is now stored at the component level and is no longer hardcoded in the `runtime` property. See serverless/serverless@9f1c57fd0f976cf4f3d3821d253c3615417129d0

Edit: Fixes #14
