### PR TITLE
Support for ES6 handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,30 +9,21 @@ Installation
 In your Serverless project:
 
 ```
-cd plugins
-npm install --prefix=. serverless-serve
+npm install serverless-serve
 ```
 
 Then in `s-project.json` add following entry to `plugins` array:
 
 ```
-    {
-      "path": "serverless-serve"
-    }
+"serverless-serve"
 ```
 
 E.g. like this:
 ```
-  plugins: [
-    {
-      "path": "serverless-serve"
-    }
-  ]
+  plugins: ["serverless-serve"]
 ```
 
-Alternatively, you can install `serveress-serve` in some parent folder (e.g. your project root), and then use `{ "path": "../node_modules/serverless-serve" }` approach.
-
-And (in main project root, not in plugins or modules folder) do:
+And in main project root do:
 
 ```
 sls serve start
@@ -71,6 +62,27 @@ Usage
 Just send your requests to `http://localhost:1465/` as it would be API Gateway.
 
 Using of this plugin with some tool like Nodemon is advised, so Serverless with restart and reload your local code after every change.
+
+Usage with Babel
+================
+
+Optionnaly, your handlers can be required with `babel-register`.
+To do so, in your `s-project.json` file, set options to be passed to babel-register like this:
+```
+{
+  /* ... */
+  "custom": {
+    "serverless-serve": {
+      "babelOptions": {
+        /* Your own options, example: */
+        presets: ["es2015", "stage-2"]
+      }
+    }
+  },
+  "plugins": ["serverless-serve", /* ... */]
+}
+```
+To view the full list of babel-register options, click [here](https://babeljs.io/docs/usage/require/)
 
 Simulation quality
 ==================

--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ module.exports = function(ServerlessPlugin, serverlessPath) {
 
       return this.S.init()
         .bind(_this)
-        .then(_this._registrBabel)
+        .then(_this._registerBabel)
         .then(_this._createApp)
         .then(_this._registerLambdas)
         .then(_this._tryInit)

--- a/index.js
+++ b/index.js
@@ -79,9 +79,9 @@ module.exports = function(ServerlessPlugin, serverlessPath) {
         res.header( 'Access-Control-Allow-Headers', 'Authorization,Content-Type,x-amz-date,x-amz-security-token' );
 
         if( req.method != 'OPTIONS' ) {
-          next()
+          next();
         } else {
-          res.status(200).end()
+          res.status(200).end();
         }
       });
     }
@@ -126,7 +126,7 @@ module.exports = function(ServerlessPlugin, serverlessPath) {
              responses: [Object] } ] }
        */
 
-        if( fun.runtime == 'nodejs' ) {
+        if( fun.getRuntime() == 'nodejs' ) {
           let handlerParts = fun.handler.split('/').pop().split('.');
           let handlerPath = path.join(fun._config.fullPath, handlerParts[0] + '.js');
           let handler;
@@ -204,7 +204,7 @@ module.exports = function(ServerlessPlugin, serverlessPath) {
                     Object.keys(endpoint.responses).forEach(key => {
                       if (!response && key != 'default' && JSON.stringify(err).match(key)) {
                         response = endpoint.responses[key];
-                      };
+                      }
                     });
 
                     result = {
@@ -241,19 +241,28 @@ module.exports = function(ServerlessPlugin, serverlessPath) {
         SCli.log( "Serverless API Gateway simulator listening on http://localhost:" + _this.evt.port );
       });
     }
+    
+    _registerBabel() {
+      return new this.S.classes.Project(this.S).load().then(project => { // Promise to load project
+        const custom = project.custom['serverless-serve'];
+        
+        if (custom && custom.babelOptions) require("babel-register")(custom.babelOptions);
+      });
+    }
 
     serve(evt) {
       let _this = this;
 
       if (_this.S.cli) {
         evt = JSON.parse(JSON.stringify(this.S.cli.options));
-        if (_this.S.cli.options.nonInteractive) _this.S._interactive = false
+        if (_this.S.cli.options.nonInteractive) _this.S._interactive = false;
       }
 
       _this.evt = evt;
 
       return this.S.init()
         .bind(_this)
+        .then(_this._registrBabel)
         .then(_this._createApp)
         .then(_this._registerLambdas)
         .then(_this._tryInit)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/Nopik/serverless-serve#readme",
   "dependencies": {
+    "babel-register": "^6.5.2",
     "bluebird": "^3.0.6",
     "body-parser": "^1.14.1",
     "express": "^4.13.3"


### PR DESCRIPTION
Hi,

I find `serverless-optimize-plugin` very handy to compile my ES6 handlers to ES5 before deploying.
But when it comes to `serverless-serve` I'm stuck if I want to use some cool ES6 features Node does not support yet.

This is a proposal of how to be able to use `babel-register` inside this plugin.
It is non-breaking and adds one new dependency (`babel-register`).

Basically, you would have to modify your `s-project.json` like this to enable this new feature:

```
{
  /* ... */
  "custom": {
    "serverless-serve": {
      "babelOptions": {
        /* Your own options, example: */
        presets: ["es2015", "stage-2"]
      }
    }
  },
  "plugins": ["serverless-serve", /* ... */]
}
```

If  `custom>serverless-serve>babelOptions` is present, the plugin activates `babel-register` with the given options, and your handlers are compiled from ES6 whenever `require` is called.

In the example above, you'd have to run `npm i babel-preset-es2015 babel-preset-state-2` in your root folder to make it work.

Also, this fixes #14 because I'm working with it.
