### PR TITLE
Allow to run functions with env variables correctly populated

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,8 +104,6 @@ module.exports = function(S) {
 
       return functions.forEach(function(fun) {
         if( -1 !== fun.getRuntime().getName().indexOf('nodejs') ) {
-          // Override s-function.json defined environment!
-          Object.getPrototypeOf( fun.getRuntime() ).getEnvVars = ()=> BbPromise.resolve( {} );
           _this.handlers[ fun.name ] = fun;
 
           fun.endpoints.forEach(function(endpoint){
@@ -174,7 +172,8 @@ module.exports = function(S) {
                   return response || responses['default'];
                 }
 
-                fun.run( _this.evt.stage, _this.evt.region, event ).then( (res)=> {
+                let runtime = fun.getRuntime();
+                runtime.run(fun,  _this.evt.stage, _this.evt.region, event).then( (res)=> {
                   if( res.status == 'success' ) {
                     resolve(Object.assign({
                       result: res.response


### PR DESCRIPTION
My lambda functions use `process.env` to read variables configured from the environment. They currently crash because functions are not populating this variables correctly. 

This PR calls the `Runtime.run` function which properly initializes env variables for the specific function.

**note**: if multiple functions use the same env variables and functions are executed concurrently,  unknown errors may happen as `process.env` will be modified nondeterministically 
